### PR TITLE
Add command-line options to specify the source asset directory

### DIFF
--- a/UIGenerator/ImageAssets.cs
+++ b/UIGenerator/ImageAssets.cs
@@ -48,15 +48,25 @@ namespace EmptyKeys.UserInterface.Generator
         }
 
         /// <summary>
-        /// Copies the images to asset directory.
+        /// Copies the images from the current working directory to the specified asset target directory.
         /// </summary>
-        /// <param name="assetsDirectory">The assets directory.</param>
-        public bool CopyImagesToAssetDirectory(string assetsDirectory)
+        /// <param name="TargetDir">The assets directory.</param>
+        public bool CopyImagesToAssetDirectory(string TargetDir)
+        {
+            string SourceDir = Path.GetDirectoryName(Environment.CurrentDirectory);
+            return CopyImagesToAssetDirectory(TargetDir, SourceDir);
+        }
+
+        /// <summary>
+        /// Copies the images from the specified source directory to the specified asset target directory.
+        /// </summary>
+        /// <param name="TargetDir">The assets directory.</param>
+        public bool CopyImagesToAssetDirectory(string TargetDir, string SourceDir)
         {
             foreach (string asset in imageAssets)
             {
-                string source = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), asset);
-                string target = Path.Combine(assetsDirectory, asset);
+                string sourceFile = Path.Combine(SourceDir, asset);
+                string target = Path.Combine(TargetDir, asset);
 
                 try
                 {
@@ -65,7 +75,7 @@ namespace EmptyKeys.UserInterface.Generator
                         Directory.CreateDirectory(Path.GetDirectoryName(target));
                     }
 
-                    File.Copy(source, target, true);
+                    File.Copy(sourceFile, target, true);
                 }
                 catch (Exception ex)
                 {

--- a/UIGenerator/ImageAssets.cs
+++ b/UIGenerator/ImageAssets.cs
@@ -61,6 +61,7 @@ namespace EmptyKeys.UserInterface.Generator
         /// Copies the images from the specified source directory to the specified asset target directory.
         /// </summary>
         /// <param name="TargetDir">The assets directory.</param>
+        /// <param name="SourceDir">The directory to copy assets from.</param>
         public bool CopyImagesToAssetDirectory(string TargetDir, string SourceDir)
         {
             foreach (string asset in imageAssets)


### PR DESCRIPTION
Using the location of the executable on disk for finding assets limits the utility of this generator app. This PR replaces the use of the executable's location with the current working directory. It also allows for overriding this path from the command line.

This also adds the ability to ignore assets (by type or just "all assets") so that if you don't use images in your XAML this app doesn't need to know about them.