### PR TITLE
Locating resources relative to the input file.

### DIFF
--- a/UIGenerator/UserInterfaceGenerator.cs
+++ b/UIGenerator/UserInterfaceGenerator.cs
@@ -41,10 +41,16 @@ namespace EmptyKeys.UserInterface.Generator
         {
             inputFileContent = RemoveClass(inputFileContent);
 
+            // Ensure resources are located relative to the input file
+            var parserContext = new ParserContext
+            {
+                BaseUri = new Uri(inputFileName, UriKind.Absolute)
+            };
+
             object source = null;
             try
             {
-                source = XamlReader.Parse(inputFileContent);
+                source = XamlReader.Parse(inputFileContent, parserContext);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This commit allows the use of relative resource dictionaries without the use of the pack URI syntax, e.g:

    <ek:UIRoot.Resources>
        <ResourceDictionary>
            <ResourceDictionary.MergedDictionaries>
                <ResourceDictionary Source="Resources.xaml"></ResourceDictionary>
            </ResourceDictionary.MergedDictionaries>
        </ResourceDictionary>
    </ek:UIRoot.Resources>

Where `Resources.xaml` is defined in the same directory as the input file.