### PR TITLE
Added DefaultAssembly parameter

### DIFF
--- a/ekUiGen/Program.cs
+++ b/ekUiGen/Program.cs
@@ -172,7 +172,7 @@ namespace ekUiGen
             if (!string.IsNullOrEmpty(defaultAssembly))
                 xaml = Regex.Replace(xaml,
                     @"xmlns(:\w+)?=\""clr-namespace:([.\w]+)(;assembly=)?\""",
-                    $@"xmlns$1=""clr-namespace:$2;assembly=" + defaultAssembly);
+                    $@"xmlns$1=""clr-namespace:$2;assembly=" + defaultAssembly + '"');
 
             UserInterfaceGenerator generator = new UserInterfaceGenerator();
             string generatedCode = string.Empty;


### PR DESCRIPTION
This will allow compilation of XAML files which use clr-namespace references from within their own assembly, which are not allowed to have assembly directives under WPF.